### PR TITLE
udistrital/sga_cliente#1378 actualizados modelos de las tablas plan_estudio y plan_estudio_proyecto_academico

### DIFF
--- a/database/migrations/20230810_091652_cambiar_tipo_dato_plan_estudio_padre.go
+++ b/database/migrations/20230810_091652_cambiar_tipo_dato_plan_estudio_padre.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"github.com/astaxie/beego/migration"
+	"io/ioutil"
+	"strings"
+)
+
+// DO NOT MODIFY
+type CambiarTipoDatoPlanEstudioPadre_20230810_091652 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &CambiarTipoDatoPlanEstudioPadre_20230810_091652{}
+	m.Created = "20230810_091652"
+
+	migration.Register("CambiarTipoDatoPlanEstudioPadre_20230810_091652", m)
+}
+
+// Run the migrations
+func (m *CambiarTipoDatoPlanEstudioPadre_20230810_091652) Up() {
+	// use m.SQL("CREATE TABLE ...") to make schema update
+	file, err := ioutil.ReadFile("../scripts/20230810_091652_cambiar_tipo_dato_plan_estudio_padre_up.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+}
+
+// Reverse the migrations
+func (m *CambiarTipoDatoPlanEstudioPadre_20230810_091652) Down() {
+	// use m.SQL("DROP TABLE ...") to reverse schema update
+	file, err := ioutil.ReadFile("../scripts/20230810_091652_cambiar_tipo_dato_plan_estudio_padre_down.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+}

--- a/database/migrations/20230813_091005_eliminar_proyecto_academico_plan_estudio_proyecto_academico.go
+++ b/database/migrations/20230813_091005_eliminar_proyecto_academico_plan_estudio_proyecto_academico.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"github.com/astaxie/beego/migration"
+	"io/ioutil"
+	"strings"
+)
+
+// DO NOT MODIFY
+type EliminarProyectoAcademicoPlanEstudioProyectoAcademico_20230813_091005 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &EliminarProyectoAcademicoPlanEstudioProyectoAcademico_20230813_091005{}
+	m.Created = "20230813_091005"
+
+	migration.Register("EliminarProyectoAcademicoPlanEstudioProyectoAcademico_20230813_091005", m)
+}
+
+// Run the migrations
+func (m *EliminarProyectoAcademicoPlanEstudioProyectoAcademico_20230813_091005) Up() {
+	// use m.SQL("CREATE TABLE ...") to make schema update
+	file, err := ioutil.ReadFile("../scripts/20230813_091005_eliminar_proyecto_academico_plan_estudio_proyecto_academico_up.sql")
+	if err != nil {
+		//handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+}
+
+// Reverse the migrations
+func (m *EliminarProyectoAcademicoPlanEstudioProyectoAcademico_20230813_091005) Down() {
+	// use m.SQL("DROP TABLE ...") to reverse schema update
+	file, err := ioutil.ReadFile("../scripts/20230813_091005_eliminar_proyecto_academico_plan_estudio_proyecto_academico_down.sql")
+	if err != nil {
+		//handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+}

--- a/database/migrations/20230813_094005_rename_orden_plan_estudio_proyecto_academico.go
+++ b/database/migrations/20230813_094005_rename_orden_plan_estudio_proyecto_academico.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"github.com/astaxie/beego/migration"
+	"io/ioutil"
+	"strings"
+)
+
+// DO NOT MODIFY
+type RenameOrdenPlanEstudioProyectoAcademico_20230813_094005 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &RenameOrdenPlanEstudioProyectoAcademico_20230813_094005{}
+	m.Created = "20230813_094005"
+
+	migration.Register("RenameOrdenPlanEstudioProyectoAcademico_20230813_094005", m)
+}
+
+// Run the migrations
+func (m *RenameOrdenPlanEstudioProyectoAcademico_20230813_094005) Up() {
+	// use m.SQL("CREATE TABLE ...") to make schema update
+	file, err := ioutil.ReadFile("../scripts/20230813_094005_rename_orden_plan_estudio_proyecto_academico_up.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+}
+
+// Reverse the migrations
+func (m *RenameOrdenPlanEstudioProyectoAcademico_20230813_094005) Down() {
+	// use m.SQL("DROP TABLE ...") to reverse schema update
+	file, err := ioutil.ReadFile("../scripts/20230813_094005_rename_orden_plan_estudio_proyecto_academico_down.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+}

--- a/database/scripts/20230810_091652_cambiar_tipo_dato_plan_estudio_padre_down.sql
+++ b/database/scripts/20230810_091652_cambiar_tipo_dato_plan_estudio_padre_down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE plan_estudios.plan_estudio ALTER COLUMN es_plan_estudio_padre SET DATA TYPE integer;
+ALTER TABLE plan_estudios.plan_estudio RENAME COLUMN es_plan_estudio_padre TO plan_estudio_padre_id;
+ALTER TABLE plan_estudios.plan_estudio ADD CONSTRAINT rel_plan_estudio_plan_estudio FOREIGN KEY (plan_estudio_padre_id)
+    REFERENCES plan_estudios.plan_estudio (id) MATCH SIMPLE
+    ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/database/scripts/20230810_091652_cambiar_tipo_dato_plan_estudio_padre_up.sql
+++ b/database/scripts/20230810_091652_cambiar_tipo_dato_plan_estudio_padre_up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE plan_estudios.plan_estudio DROP CONSTRAINT IF EXISTS rel_plan_estudio_plan_estudio CASCADE;
+ALTER TABLE plan_estudios.plan_estudio ALTER COLUMN plan_estudio_padre_id SET DATA TYPE bool USING (plan_estudio_padre_id::int::bool);
+ALTER TABLE plan_estudios.plan_estudio RENAME COLUMN plan_estudio_padre_id TO es_plan_estudio_padre;

--- a/database/scripts/20230813_091005_eliminar_proyecto_academico_plan_estudio_proyecto_academico_down.sql
+++ b/database/scripts/20230813_091005_eliminar_proyecto_academico_plan_estudio_proyecto_academico_down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plan_estudios.plan_estudio_proyecto_academico ADD COLUMN proyecto_academico_id INTEGER NULL;

--- a/database/scripts/20230813_091005_eliminar_proyecto_academico_plan_estudio_proyecto_academico_up.sql
+++ b/database/scripts/20230813_091005_eliminar_proyecto_academico_plan_estudio_proyecto_academico_up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plan_estudios.plan_estudio_proyecto_academico DROP COLUMN proyecto_academico_id;

--- a/database/scripts/20230813_094005_rename_orden_plan_estudio_proyecto_academico_down.sql
+++ b/database/scripts/20230813_094005_rename_orden_plan_estudio_proyecto_academico_down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plan_estudios.plan_estudio_proyecto_academico RENAME COLUMN orden_plan TO orden_proyecto;

--- a/database/scripts/20230813_094005_rename_orden_plan_estudio_proyecto_academico_up.sql
+++ b/database/scripts/20230813_094005_rename_orden_plan_estudio_proyecto_academico_up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plan_estudios.plan_estudio_proyecto_academico RENAME COLUMN orden_proyecto TO orden_plan;

--- a/models/plan_estudio.go
+++ b/models/plan_estudio.go
@@ -26,7 +26,7 @@ type PlanEstudio struct {
 	Activo                       bool              `orm:"column(activo)"`
 	FechaCreacion                string            `orm:"column(fecha_creacion);type(timestamp without time zone)"`
 	FechaModificacion            string            `orm:"column(fecha_modificacion);type(timestamp without time zone)"`
-	PlanEstudioPadreId           *PlanEstudio      `orm:"column(plan_estudio_padre_id);rel(fk)"`
+	EsPlanEstudioPadre           bool              `orm:"column(es_plan_estudio_padre)"`
 	EstadoAprobacionId           *EstadoAprobacion `orm:"column(estado_aprobacion_id);rel(fk)"`
 }
 

--- a/models/plan_estudio_proyecto_academico.go
+++ b/models/plan_estudio_proyecto_academico.go
@@ -10,13 +10,12 @@ import (
 )
 
 type PlanEstudioProyectoAcademico struct {
-	Id                  int          `orm:"column(id);pk"`
-	PlanEstudioId       *PlanEstudio `orm:"column(plan_estudio_id);rel(fk)"`
-	ProyectoAcademicoId int          `orm:"column(proyecto_academico_id)"`
-	OrdenProyecto       string       `orm:"column(orden_proyecto);type(json)"`
-	Activo              bool         `orm:"column(activo)"`
-	FechaCreacion       string       `orm:"column(fecha_creacion);type(timestamp without time zone)"`
-	FechaModificacion   string       `orm:"column(fecha_modificacion);type(timestamp without time zone)"`
+	Id                int          `orm:"column(id);pk"`
+	PlanEstudioId     *PlanEstudio `orm:"column(plan_estudio_id);rel(fk)"`
+	OrdenPlan         string       `orm:"column(orden_plan);type(json)"`
+	Activo            bool         `orm:"column(activo)"`
+	FechaCreacion     string       `orm:"column(fecha_creacion);type(timestamp without time zone)"`
+	FechaModificacion string       `orm:"column(fecha_modificacion);type(timestamp without time zone)"`
 }
 
 func (t *PlanEstudioProyectoAcademico) TableName() string {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -581,6 +581,9 @@
                 "CodigoAbreaviacion": {
                     "type": "string"
                 },
+                "EsPlanEstudioPadre": {
+                    "type": "boolean"
+                },
                 "EspaciosSemestreDistribucion": {
                     "type": "string"
                 },
@@ -610,9 +613,6 @@
                 },
                 "Observacion": {
                     "type": "string"
-                },
-                "PlanEstudioPadreId": {
-                    "$ref": "#/definitions/models.PlanEstudio"
                 },
                 "ProyectoAcademicoId": {
                     "type": "integer",
@@ -647,15 +647,11 @@
                     "type": "integer",
                     "format": "int64"
                 },
-                "OrdenProyecto": {
+                "OrdenPlan": {
                     "type": "string"
                 },
                 "PlanEstudioId": {
                     "$ref": "#/definitions/models.PlanEstudio"
-                },
-                "ProyectoAcademicoId": {
-                    "type": "integer",
-                    "format": "int64"
                 }
             }
         }


### PR DESCRIPTION
Detalles:
- Cambiado campo plan_estudio_padre a es_plan_estudio de tipo integer a bool para identificar el plan de estudio padre que almacenará el orden del plan de estudio compuesto por varios planes.
- Removido campo proyecto_academico_id de la tabla plan_estudio_proyecto_academico
- Removido cambiado nombre del campo orden_proyecto a orden_plan de la tabla plan_estudio_proyecto_academico